### PR TITLE
Fixing a reference to 0.0.1 version of extjfx-test

### DIFF
--- a/extjfx-chart/pom.xml
+++ b/extjfx-chart/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>cern.extjfx</groupId>
 			<artifactId>extjfx-test</artifactId>
-			<version>0.0.1</version>
+			<version>0.0.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
This should be 0.0.2 because that is the version that we are currently building.